### PR TITLE
适配 ppl.common 最新的逻辑

### DIFF
--- a/src/models/llama/llama_worker.cc
+++ b/src/models/llama/llama_worker.cc
@@ -665,11 +665,10 @@ void LLaMAWorker::Work() {
         check_res.cache_index = INT64_MAX;
         check_res.rest_iters = -1;
         check_res.first_fill_len = req.token_id_list.size();
-        check_res.max_tokens_per_step += check_res.first_fill_len;
-
         if (check_res.max_tokens_per_step > worker_config_.max_tokens_per_step) {
             return false;
         }
+        check_res.max_tokens_per_step += check_res.first_fill_len;
 
         if (check_res.first_fill_len + req.orig->generation_length > (size_t)worker_config_.max_tokens_per_request) {
             check_res.rest_iters = worker_config_.max_tokens_per_request - check_res.first_fill_len;


### PR DESCRIPTION
1. ppl.common 最新的代码里面StaticThreadPool 有一些改动，导致serving会卡住。
2.   如果请求的text长度大于配置的max_tokens_per_step会导致这个请求一直卡在那，不反回结果，也不能再服务别的请求， 所以直接让这个请求得到调度并快速返回。